### PR TITLE
Enable Bootstrap CSS Grid

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -49,10 +49,7 @@
 								"input": "public"
 							}
 						],
-						"styles": [
-							"node_modules/bootstrap/dist/css/bootstrap.css",
-							"src/style/style.scss"
-						],
+						"styles": ["src/style/style.scss"],
 						"scripts": [
 							"node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
 						]

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -1,5 +1,4 @@
-@use "abstract";
-
-@use "base";
-
-@use "theme";
+@import "abstract/variable";
+@import "bootstrap/scss/bootstrap";
+@import "base";
+@import "theme";


### PR DESCRIPTION
## Summary
- load Bootstrap's SCSS with CSS Grid enabled
- drop prebuilt bootstrap.css from build config

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build` *(fails: Inlining of fonts failed)*

------
https://chatgpt.com/codex/tasks/task_e_688f49640c4c8327bc9cc6ca2dca6014